### PR TITLE
#184651056  Configure Swagger Documentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,35 @@
 import express from 'express'
 import dotenv from 'dotenv'
+import swaggerJSDoc from 'swagger-jsdoc'
+import swaggerUi from 'swagger-ui-express'
+import blogRoutes from './src/routes/index.js'
 
 const app = express()
 
 dotenv.config()
 const PORT = process.env.PORT
+
+const options={
+    definition:{
+        openapi:"3.0.0",
+        info:{
+            title:"API Library",
+            version:1.0,
+            description:"Swagger Api Documentation",
+        },
+        servers:[
+            {
+                url:process.env.SWAGGER_URL     // Port Number on this URL must be the same as the Server Port Number 
+            }
+        ], 
+    },
+
+        apis:['./src/routes/index.js','./src/config/swagger.js']
+}
+const specs= swaggerJSDoc(options)
+app.use('/myapi',swaggerUi.serve,swaggerUi.setup(specs))
+
+app.use('',blogRoutes)
 
 app.get('/', (req, res) => {
     res.status(200).json('Hello World!')

--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
     "eslint-plugin-node": "^11.1.0",
     "express": "^4.18.2",
     "jest": "^29.5.0",
-    "supertest": "^6.3.3" 
-  },  
+    "supertest": "^6.3.3",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^4.6.2"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/atlp-rwanda/Team-Sostene-E-commerce-bn.git"

--- a/src/config/swagger.js
+++ b/src/config/swagger.js
@@ -1,0 +1,10 @@
+/**
+ * @swagger
+ * /test:
+ *  get:
+ *      summary: simple test
+ *      description: This API returns a json message
+ *      responses:
+ *          200:
+ *              description: GET json Message
+ */

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -6,5 +6,14 @@
  * A route is a section of Express code that
  * associates an HTTP verb ( GET , POST , PUT , DELETE , etc.),
  * a URL path/pattern, and a function that is called to handle that pattern
- *
+ * 
  */
+
+import Express from "express";
+const Router = Express.Router()
+
+Router.get('/test',(req,res)=>{
+    res.status(200).json({"message":"TESTED"})
+})
+
+export default Router


### PR DESCRIPTION
- swagger docs congiguration

[Delivers #184651056]

### What does this PR do?
Creates a base configuration for swagger documentation
### Description of Task to be completed?
- implemented swagger doc
- able to test APIs using swagger UI
### How should this be manually tested
- connect to the server: **npm run start**
- in the browser use: **http://site_url/myapi**
### Any background context you want to provide?
- this will make it possible to make documentation using swagger annotations


